### PR TITLE
Add usuarios Prisma model and CRUD login endpoints

### DIFF
--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const sanitizeUsuario = <T extends { password?: unknown }>(usuario: T) => {
+  const { password: _password, ...safeUsuario } = usuario;
+  void _password;
+  return safeUsuario;
+};
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { nombre_usuario, password } = body ?? {};
+
+    if (!nombre_usuario || !password) {
+      return NextResponse.json(
+        { message: "Los campos nombre_usuario y password son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const usuario = await prisma.usuarios.findUnique({
+      where: { nombre_usuario },
+    });
+
+    if (!usuario || !usuario.activo || usuario.password !== password) {
+      return NextResponse.json(
+        { message: "Credenciales inválidas o usuario inactivo." },
+        { status: 401 }
+      );
+    }
+
+    return NextResponse.json(sanitizeUsuario(usuario));
+  } catch (error) {
+    console.error("Error al iniciar sesión", error);
+    return NextResponse.json({ message: "Error interno del servidor." }, { status: 500 });
+  }
+}

--- a/app/api/usuarios/[id]/route.ts
+++ b/app/api/usuarios/[id]/route.ts
@@ -1,0 +1,128 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma, Prisma } from "@/lib/prisma";
+
+const sanitizeUsuario = <T extends { password?: unknown }>(usuario: T) => {
+  const { password: _password, ...safeUsuario } = usuario;
+  void _password;
+  return safeUsuario;
+};
+
+const parseId = (id: string) => {
+  const parsed = Number(id);
+  return Number.isInteger(parsed) ? parsed : null;
+};
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const usuarioId = parseId(params.id);
+
+  if (usuarioId === null) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  const usuario = await prisma.usuarios.findUnique({
+    where: { usuario_id: usuarioId },
+  });
+
+  if (!usuario) {
+    return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+  }
+
+  return NextResponse.json(sanitizeUsuario(usuario));
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  return updateUsuario(request, params, false);
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  return updateUsuario(request, params, true);
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const usuarioId = parseId(params.id);
+
+  if (usuarioId === null) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    await prisma.usuarios.delete({
+      where: { usuario_id: usuarioId },
+    });
+
+    return NextResponse.json({ message: "Usuario eliminado correctamente." });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2025") {
+      return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+    }
+
+    console.error("Error al eliminar usuario", error);
+    return NextResponse.json({ message: "Error interno del servidor." }, { status: 500 });
+  }
+}
+
+async function updateUsuario(
+  request: NextRequest,
+  params: { id: string },
+  isPartial: boolean
+) {
+  const usuarioId = parseId(params.id);
+
+  if (usuarioId === null) {
+    return NextResponse.json({ message: "Identificador inválido." }, { status: 400 });
+  }
+
+  try {
+    const body = await request.json();
+    const { correo, password, nombre_usuario, activo } = body ?? {};
+
+    if (!isPartial && (!correo || !password || !nombre_usuario)) {
+      return NextResponse.json(
+        { message: "Los campos correo, password y nombre_usuario son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const data: Prisma.usuariosUpdateInput = {};
+
+    if (correo !== undefined) data.correo = correo;
+    if (password !== undefined) data.password = password;
+    if (nombre_usuario !== undefined) data.nombre_usuario = nombre_usuario;
+    if (activo !== undefined) data.activo = activo;
+
+    const usuarioActualizado = await prisma.usuarios.update({
+      where: { usuario_id: usuarioId },
+      data,
+    });
+
+    return NextResponse.json(sanitizeUsuario(usuarioActualizado));
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2025") {
+        return NextResponse.json({ message: "Usuario no encontrado." }, { status: 404 });
+      }
+
+      if (error.code === "P2002") {
+        return NextResponse.json(
+          { message: "El correo o nombre de usuario ya se encuentra registrado." },
+          { status: 409 }
+        );
+      }
+    }
+
+    console.error("Error al actualizar usuario", error);
+    return NextResponse.json({ message: "Error interno del servidor." }, { status: 500 });
+  }
+}

--- a/app/api/usuarios/route.ts
+++ b/app/api/usuarios/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma, Prisma } from "@/lib/prisma";
+
+const sanitizeUsuario = <T extends { password?: unknown }>(usuario: T) => {
+  const { password: _password, ...safeUsuario } = usuario;
+  void _password;
+  return safeUsuario;
+};
+
+export async function GET() {
+  const usuarios = await prisma.usuarios.findMany({
+    orderBy: { usuario_id: "asc" },
+  });
+
+  return NextResponse.json(usuarios.map(sanitizeUsuario));
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { correo, password, nombre_usuario, activo } = body ?? {};
+
+    if (!correo || !password || !nombre_usuario) {
+      return NextResponse.json(
+        { message: "Los campos correo, password y nombre_usuario son obligatorios." },
+        { status: 400 }
+      );
+    }
+
+    const nuevoUsuario = await prisma.usuarios.create({
+      data: {
+        correo,
+        password,
+        nombre_usuario,
+        activo: typeof activo === "boolean" ? activo : undefined,
+      },
+    });
+
+    return NextResponse.json(sanitizeUsuario(nuevoUsuario), { status: 201 });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return NextResponse.json(
+        { message: "El correo o nombre de usuario ya se encuentra registrado." },
+        { status: 409 }
+      );
+    }
+
+    console.error("Error al crear usuario", error);
+    return NextResponse.json(
+      { message: "Error interno del servidor." },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from "@/app/generated/prisma";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+export type { Prisma } from "@/app/generated/prisma";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,3 +109,12 @@ enum promotions_promo_type {
   PRODUCT
   QTY
 }
+
+model usuarios {
+  usuario_id      Int      @id @default(autoincrement())
+  correo          String   @unique(map: "usuarios_correo_key") @db.VarChar(191)
+  password        String   @db.VarChar(255)
+  activo          Boolean  @default(true)
+  nombre_usuario  String   @unique(map: "usuarios_nombre_usuario_key") @db.VarChar(191)
+  fecha_creacion  DateTime @default(now()) @db.DateTime(0)
+}


### PR DESCRIPTION
## Summary
- add a Prisma `usuarios` model with correo, password, activo, nombre_usuario y fecha_creacion
- add a shared Prisma client helper for API routes
- implement Next.js API routes for usuarios CRUD and login validation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddc8d5aa08832f97e106f2947475c5